### PR TITLE
Fix blank screen by initializing grid and using ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Philosophical Life</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
   <script type="module" src="main.js"></script>
 </head>
 <body>

--- a/main.js
+++ b/main.js
@@ -1,15 +1,16 @@
-const THREE = window.THREE;
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 // In the vast emptiness of the canvas, each square ponders its existence.
 const container = document.getElementById('container');
 const scene = new THREE.Scene();
 const renderer = new THREE.WebGLRenderer();
-renderer.setSize(container.clientWidth, container.clientHeight);
+renderer.setSize(window.innerWidth, window.innerHeight - 40);
 container.appendChild(renderer.domElement);
-const camera = new THREE.OrthographicCamera(0, container.clientWidth, container.clientHeight, 0, 0, 1);
+const camera = new THREE.OrthographicCamera(0, window.innerWidth, window.innerHeight - 40, 0, 0, 10);
+camera.position.z = 1;
 scene.add(camera);
 const cellSize = 20;
-const cols = Math.floor(container.clientWidth / cellSize);
-const rows = Math.floor(container.clientHeight / cellSize);
+const cols = Math.floor(window.innerWidth / cellSize);
+const rows = Math.floor((window.innerHeight - 40) / cellSize);
 // The universe contemplates a simple square for all beings.
 const geometry = new THREE.PlaneGeometry(cellSize, cellSize);
 const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
@@ -20,7 +21,11 @@ for (let y = 0; y < rows; y++) {
         const mesh = new THREE.Mesh(geometry, material.clone());
         mesh.position.set(x * cellSize + cellSize / 2, y * cellSize + cellSize / 2, 0);
         scene.add(mesh);
-        row.push({ mesh, alive: false, dying: false });
+        const alive = Math.random() > 0.7;
+        if (alive) {
+            mesh.material.color.set('#000000');
+        }
+        row.push({ mesh, alive, dying: false });
     }
     cells.push(row);
 }
@@ -88,12 +93,12 @@ function update() {
         randomRule(); // Silently rewrite the laws of nature.
     }
 }
-function render() {
+function animate() {
     update();
     renderer.render(scene, camera);
-    requestAnimationFrame(render);
+    requestAnimationFrame(animate);
 }
-render();
+animate();
 // Pretend we obey the user's will, yet we continue unabated.
 const button = document.getElementById('startStop');
 let pretendRunning = false;

--- a/main.ts
+++ b/main.ts
@@ -1,18 +1,19 @@
-const THREE: any = (window as any).THREE;
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 
 // In the vast emptiness of the canvas, each square ponders its existence.
 const container = document.getElementById('container') as HTMLElement;
 const scene = new THREE.Scene();
 const renderer = new THREE.WebGLRenderer();
-renderer.setSize(container.clientWidth, container.clientHeight);
+renderer.setSize(window.innerWidth, window.innerHeight - 40);
 container.appendChild(renderer.domElement);
 
-const camera = new THREE.OrthographicCamera(0, container.clientWidth, container.clientHeight, 0, 0, 1);
+const camera = new THREE.OrthographicCamera(0, window.innerWidth, window.innerHeight - 40, 0, 0, 10);
+camera.position.z = 1;
 scene.add(camera);
 
 const cellSize = 20;
-const cols = Math.floor(container.clientWidth / cellSize);
-const rows = Math.floor(container.clientHeight / cellSize);
+const cols = Math.floor(window.innerWidth / cellSize);
+const rows = Math.floor((window.innerHeight - 40) / cellSize);
 
 // The universe contemplates a simple square for all beings.
 const geometry = new THREE.PlaneGeometry(cellSize, cellSize);
@@ -32,7 +33,11 @@ for (let y = 0; y < rows; y++) {
     const mesh = new THREE.Mesh(geometry, material.clone());
     mesh.position.set(x * cellSize + cellSize / 2, y * cellSize + cellSize / 2, 0);
     scene.add(mesh);
-    row.push({mesh, alive: false, dying: false});
+    const alive = Math.random() > 0.7;
+    if (alive) {
+      (mesh.material as any).color.set('#000000');
+    }
+    row.push({mesh, alive, dying: false});
   }
   cells.push(row);
 }
@@ -102,13 +107,13 @@ function update() {
   }
 }
 
-function render() {
+function animate() {
   update();
   renderer.render(scene, camera);
-  requestAnimationFrame(render);
+  requestAnimationFrame(animate);
 }
 
-render();
+animate();
 
 // Pretend we obey the user's will, yet we continue unabated.
 const button = document.getElementById('startStop') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- load modern three.js as an ES module
- size the renderer based on the window instead of a zero-size container
- initialize cells with random life so the grid is visible
- rename the render loop to `animate`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685648a4f35483329f9e0184908c62c6