### PR TITLE
Slowed Game of Life animation

### DIFF
--- a/main.js
+++ b/main.js
@@ -93,8 +93,14 @@ function update() {
         randomRule(); // Silently rewrite the laws of nature.
     }
 }
+const updateInterval = 500; // milliseconds between generations
+let lastUpdateTime = performance.now();
 function animate() {
-    update();
+    const now = performance.now();
+    if (now - lastUpdateTime >= updateInterval) {
+        update();
+        lastUpdateTime = now;
+    }
     renderer.render(scene, camera);
     requestAnimationFrame(animate);
 }

--- a/main.ts
+++ b/main.ts
@@ -107,8 +107,15 @@ function update() {
   }
 }
 
+const updateInterval = 500; // milliseconds between generations
+let lastUpdateTime = performance.now();
+
 function animate() {
-  update();
+  const now = performance.now();
+  if (now - lastUpdateTime >= updateInterval) {
+    update();
+    lastUpdateTime = now;
+  }
   renderer.render(scene, camera);
   requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- add a delay between generations so the animation is easier to watch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68564a1310708332974122a9c780d248